### PR TITLE
niv nixpkgs: update 29eddfc3 -> a438aed5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29eddfc36d720dcc4822581175217543b387b1e8",
-        "sha256": "1gqv2m7plkladd3va664xyqb962pqs4pizzibvkm1nh0f4rfpxvy",
+        "rev": "a438aed5a6ceda6beaa998af1c67a38f4b4c3156",
+        "sha256": "0di45qxffbqpn0rwzaq20dlm25asvwfwqwy66zysrxq8xgk8vjll",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/29eddfc36d720dcc4822581175217543b387b1e8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a438aed5a6ceda6beaa998af1c67a38f4b4c3156.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [NixOS/nixpkgs@29eddfc3...a438aed5](https://github.com/NixOS/nixpkgs/compare/29eddfc36d720dcc4822581175217543b387b1e8...a438aed5a6ceda6beaa998af1c67a38f4b4c3156)

* [`42cca0d8`](https://github.com/NixOS/nixpkgs/commit/42cca0d8ea689ba0b7fc390422c7f0925c5c0eac) mariadb-connector-c: add mysqlclient.pc pkgconfig symlink
* [`5e24f4b3`](https://github.com/NixOS/nixpkgs/commit/5e24f4b3b3a5439a67f9027d40e0889070232f44) openssl(_1_1): patch CVE-2019-1551
* [`0e5ef8c4`](https://github.com/NixOS/nixpkgs/commit/0e5ef8c4709e44dfdf22f742c1ebf92d2420e1cf) openssl: 1.1.1d -> 1.1.1f
* [`3b383195`](https://github.com/NixOS/nixpkgs/commit/3b3831957fe82543edf695a2b5dd0dc9db350328) go_1_14: 1.14 -> 1.14.1
* [`eeeb2bf8`](https://github.com/NixOS/nixpkgs/commit/eeeb2bf8035b309a636d596de6a3b1d52ca427b1) nixos/release-notes: mention that dhcpcd stopped giving IPv4 addresses to bridges by default
* [`1e19a825`](https://github.com/NixOS/nixpkgs/commit/1e19a82577ea22b2d6bdd34689ad523cf8acc27f) apacheHttpd: 2.4.41 -> 2.4.43
* [`6e14cf0e`](https://github.com/NixOS/nixpkgs/commit/6e14cf0e620f49510680b106cba1ebdee98bd3be) itstool: fix double-shebang issue on macOS
* [`7601af23`](https://github.com/NixOS/nixpkgs/commit/7601af232ba8bdae2fa28329e9b7e1776dfc9272) itstool: use wrapPython to fix double shebang on macOS
* [`d815dc4b`](https://github.com/NixOS/nixpkgs/commit/d815dc4b681596db53400ecc983da63d087275d5) Merge NixOS/nixpkgs#84273: gnutls: 3.6.12 -> 3.6.13 [security]
* [`ee47f528`](https://github.com/NixOS/nixpkgs/commit/ee47f5285f9c162c6afaa425a0f67ae8ca90732a) ceph: 14.2.6 -> 14.2.7
* [`74ee45c4`](https://github.com/NixOS/nixpkgs/commit/74ee45c435dc2886ab2311e213c466eefcb52b5f) ceph: 14.2.7 -> 14.2.8
* [`637325d6`](https://github.com/NixOS/nixpkgs/commit/637325d63f21480c23f3e61f98772390c446fd97) nixos/tests/ceph: Fix pg number to power of 2
* [`f7522984`](https://github.com/NixOS/nixpkgs/commit/f7522984c4e43c238a070d180919ae8cd23d0f70) brave: 1.5.115 -> 1.5.123
* [`6570f2ae`](https://github.com/NixOS/nixpkgs/commit/6570f2aec57c8e78e9d0902affc2e97562925b43) haskellPackages.amqp-utils: fix amqp-0.19 dependency
* [`3c700b8a`](https://github.com/NixOS/nixpkgs/commit/3c700b8aa669376d4fdf9567e452a1898fdcd3a6) cargo-make: 0.30.2 -> 0.30.4
* [`4291ef9b`](https://github.com/NixOS/nixpkgs/commit/4291ef9bb6711f4347df0dfc8b613fdc04895ba0) prometheus-wireguard-exporter: 3.2.4 -> 3.3.0
* [`612a2978`](https://github.com/NixOS/nixpkgs/commit/612a2978de1143094810878f89ee9c8d1e421c5f) libvpx_1_8: init at 1.8.2
* [`8aa68345`](https://github.com/NixOS/nixpkgs/commit/8aa68345259bc598d29487c5960844fc5b9bd838) firefox: prepare for version 75
* [`37e814ba`](https://github.com/NixOS/nixpkgs/commit/37e814ba759999d06b054a9b567dfc723864bde6) firefox: 74.0.1 -> 75.0
* [`fb97dfdc`](https://github.com/NixOS/nixpkgs/commit/fb97dfdcfa8912ab1d94df0353239ff0e19c5f6c) firefox-esr-68: 68.6.1esr -> 68.7.0esr
* [`9b3e192b`](https://github.com/NixOS/nixpkgs/commit/9b3e192bcb8096fddf928c9e62573e0188481038) firefox-bin: 74.0.1 -> 75.0
* [`f545f8ec`](https://github.com/NixOS/nixpkgs/commit/f545f8ec146770841e7f82224caf162a8377b44a) firefox-beta-bin: 75.0b11 -> 76.0b1
* [`5e9ae037`](https://github.com/NixOS/nixpkgs/commit/5e9ae03746c8b2a52351804504d56ff1406252e0) firefox-devedition-bin: 75.0b12 -> 76.0b1
* [`c5a806cf`](https://github.com/NixOS/nixpkgs/commit/c5a806cfc05696ae45a48891e25e10c28b61f104) haskellPackages.pandoc-crossref: downgrade to latest working
* [`5b340635`](https://github.com/NixOS/nixpkgs/commit/5b3406359436dc51d65d2916767f25b2e710c391) tmuxPlugins: upgrade all to latest
* [`6be1626d`](https://github.com/NixOS/nixpkgs/commit/6be1626da54d9ee3748491e59d957965a8b19caf) nixos: kafka test: fix building for other arches
* [`d41fe836`](https://github.com/NixOS/nixpkgs/commit/d41fe836331788ab12af2c7cc9e78fab4408426e) alt-ergo: 2.3.1 → 2.3.2
* [`ef5b4301`](https://github.com/NixOS/nixpkgs/commit/ef5b4301fcb3ca4c1e3794cfa89ab91124bbfa28) signal-desktop: 1.32.3 -> 1.33.0
* [`1e8fc3dd`](https://github.com/NixOS/nixpkgs/commit/1e8fc3dd4d7195b01ff117adb3dbe01649ce3bf4) gitAndTools.gh: 0.5.3 -> 0.5.4
* [`ca75c088`](https://github.com/NixOS/nixpkgs/commit/ca75c088e9e44637b7380ea2887fda64e3d74a6c) gitAndTools.gh: 0.5.4 -> 0.5.5
* [`1d6ad14c`](https://github.com/NixOS/nixpkgs/commit/1d6ad14c73e97cf5c11a34d77396f86990c92b52) gitAndTools.gh: 0.5.5 -> 0.5.6
* [`085b7360`](https://github.com/NixOS/nixpkgs/commit/085b7360d50682992bd1e3ce1525060d675ff21d) gitAndTools.gh: 0.5.6 -> 0.5.7
* [`86a179a7`](https://github.com/NixOS/nixpkgs/commit/86a179a74bbb6a9e22462d1f88a5aa89f866e1fd) gitAndTools.gh: 0.5.7 -> 0.6.0
* [`ba71d71c`](https://github.com/NixOS/nixpkgs/commit/ba71d71c13f1da75f4912dc429dc19d19988db3b) gitAndTools.gh 0.6.0 -> 0.6.1
* [`f7b3dfc9`](https://github.com/NixOS/nixpkgs/commit/f7b3dfc9d80a108e13c781240bfe398c855176f4) gitAndTools.gh: 0.6.1 -> 0.6.2
* [`cf7513bc`](https://github.com/NixOS/nixpkgs/commit/cf7513bc271ddda5b0a91eb7c68ac965c8b61085) gitAndTools.gh: 0.6.2 -> 0.6.3
* [`fbd0974d`](https://github.com/NixOS/nixpkgs/commit/fbd0974dffdec637217fa301066b64be89c3a656) gitAndTools.gh: 0.6.3 -> 0.6.4
* [`df50124d`](https://github.com/NixOS/nixpkgs/commit/df50124d6320ad949c00a443c757dad183779d04) chromium: Ignore unknown warning options
* [`85e8548a`](https://github.com/NixOS/nixpkgs/commit/85e8548a1fa71c3af3e43f83e91d9bb7bfe9e32f) chromiumBeta: Fix the build
* [`a62dac34`](https://github.com/NixOS/nixpkgs/commit/a62dac34e6f8b97e7a57cdfae50ba44309498b7e) chromium: 80.0.3987.163 -> 81.0.4044.92
* [`3cfa78fe`](https://github.com/NixOS/nixpkgs/commit/3cfa78fe304a59d3f7ced2638b83e2e602059448) chromiumDev: Fix the build
* [`224a5e5b`](https://github.com/NixOS/nixpkgs/commit/224a5e5b05a5521bd6d061009cb18122e138fbae) chromiumDev: Add the missing setuptools dependency
* [`6193a9e2`](https://github.com/NixOS/nixpkgs/commit/6193a9e24232d2f16a0c6eb59b15a8a760d96a96) nixos/release-combined.nix: test hibernate only on x86_64
* [`2d68afda`](https://github.com/NixOS/nixpkgs/commit/2d68afdaab77994501c17a1b04a24b6b9df3ff6c) linux: 5.4.30 -> 5.4.31
* [`c1af4f35`](https://github.com/NixOS/nixpkgs/commit/c1af4f35b75af4e510cde99d303fe4d979113563) linux: 5.5.15 -> 5.5.16
* [`78e69d93`](https://github.com/NixOS/nixpkgs/commit/78e69d9306f829f68b6e44c4373db799ff4e5c02) linuxPackages.acpi-call: switch to nix-community fork
* [`c6758ee1`](https://github.com/NixOS/nixpkgs/commit/c6758ee13dc551d86db4b7f5f3ae4cfe128de086) bundler: 1.17.3 -> 2.1.4
* [`97f1e863`](https://github.com/NixOS/nixpkgs/commit/97f1e8638710fa8052a94aab37156d3c100fbeec) update versions in Gemfile.lock
* [`f16ed9f7`](https://github.com/NixOS/nixpkgs/commit/f16ed9f7150175b95232b68144cecf648df8552e) set GEM_HOME via Gem.paths
* [`4ca13721`](https://github.com/NixOS/nixpkgs/commit/4ca13721d914b71d0af8eb601e1e55cd32880399) vocal: add missing glib-networking
* [`6d495931`](https://github.com/NixOS/nixpkgs/commit/6d4959314c1b77d927ebd29bd2cb127dd35f6fb2) cawbird: 1.0.4 -> 1.0.5
* [`5ac5f503`](https://github.com/NixOS/nixpkgs/commit/5ac5f503b2a0217ab87ec7036401970e6825e43b) bazel_0_26: fix linker flags for darwin (NixOS/nixpkgs#84614)
* [`f56a3e1a`](https://github.com/NixOS/nixpkgs/commit/f56a3e1aacbf6f64004d1fc6504c7c721647310c) linuxPackages.nvidia_x11: 440.64 -> 440.82
* [`48a01954`](https://github.com/NixOS/nixpkgs/commit/48a019541667c45bd7b8177b0490bb863d82ecfd) haskell.compiler.ghc822Binary: propagate llvm dependency
* [`377b0248`](https://github.com/NixOS/nixpkgs/commit/377b0248c50b2a83c3d16ec0fc092c0c9eb91ae4) acme: create certificates in subdirectory
* [`c25e25f4`](https://github.com/NixOS/nixpkgs/commit/c25e25f46f696c851ed9fd58f4542d9ca9d06e4e) hydra: 2020-03-24 -> 2020-04-07
* [`253f8a76`](https://github.com/NixOS/nixpkgs/commit/253f8a76fa35f211d22cfe701015d358b9fe97b4) emacsPackages: Add standalone agda-input package that doesn't require building Agda.
* [`aa4ec3bb`](https://github.com/NixOS/nixpkgs/commit/aa4ec3bb378b165539d6d5cd6e53b2a219148de4) xorg.xorgserver: 1.20.7 -> 1.20.8
* [`5ad2b732`](https://github.com/NixOS/nixpkgs/commit/5ad2b732e9ed053e3dd34c46c5eef1f6adebb511) kwallet-pam: unset QT_PLUGIN_PATH
* [`84216729`](https://github.com/NixOS/nixpkgs/commit/842167291c8d173adf99140bdcc2771cbe11f5b4) Merge NixOS/nixpkgs#84773: thunderbird*: 68.6.0 -> 68.7.0
* [`5f6ba36f`](https://github.com/NixOS/nixpkgs/commit/5f6ba36fd289d06cef3b1a802232d26d99ffb6d1) Merge NixOS/nixpkgs#82267: sane-airscan: init at 0.9.17
* [`4efd7281`](https://github.com/NixOS/nixpkgs/commit/4efd728157c40d4a691c6022a46a7e1b3e6ae1e0) unit: 1.14.0 -> 1.15.0
* [`56eb4066`](https://github.com/NixOS/nixpkgs/commit/56eb40663120843638e820aa0859cdcc42d249e0) unit: 1.15.0 -> 1.16.0
* [`75146059`](https://github.com/NixOS/nixpkgs/commit/7514605998c9d75a78d13ff88c24fb95461e89c8) vscodium: 1.41.1 -> 1.42.0
* [`95ca22a4`](https://github.com/NixOS/nixpkgs/commit/95ca22a4182c5d8a98d9e702236ef2f28bd88975) vscode, vscodium: 1.42.0 -> 1.42.1
* [`35b1992f`](https://github.com/NixOS/nixpkgs/commit/35b1992f6d65c9f5e195b96726ea19ac5a4a6afe) vscode: specify runtimeDependencies instead of LD_LIBRARY_PATH
* [`5c8fd2d9`](https://github.com/NixOS/nixpkgs/commit/5c8fd2d9e184d69ea242a4cf4ba057f1c087753a) vscode, vscodium: 1.42.1 -> 1.43.0
* [`d6209e54`](https://github.com/NixOS/nixpkgs/commit/d6209e540c21c65e203f6faf88fb98f07d393471) vscode: fix build on darwin
* [`de5269a3`](https://github.com/NixOS/nixpkgs/commit/de5269a3ffa162b8f2fe94ce4bb969c6bd64ba75) vscode: add backports notice
* [`13d0920d`](https://github.com/NixOS/nixpkgs/commit/13d0920dad4ac4d73ae4187381a7d5b717c10655) vscodium: add backports notice
* [`829f6560`](https://github.com/NixOS/nixpkgs/commit/829f656072fe2238b424eaae48976f2789c0bc69) vscode: 1.43.0 -> 1.43.2
* [`763a3b46`](https://github.com/NixOS/nixpkgs/commit/763a3b46eca2ce763352adde44bf75e2ea409b5a) vscodium: 1.43.0 -> 1.43.2
* [`69f15290`](https://github.com/NixOS/nixpkgs/commit/69f1529084cc4f6060f1727685b9230609f2cf1b) vscode, vscodium: 1.43.2 -> 1.44.0
* [`5f33f338`](https://github.com/NixOS/nixpkgs/commit/5f33f338ce4dbd1bf6f7f70998c41622fb2098ea) thermald: also install thermal-conf.xml into $out
* [`a74e7092`](https://github.com/NixOS/nixpkgs/commit/a74e7092b0761f177a2bdb84693e1859de78950d) gitAndTools.tig: 2.5.0 -> 2.5.1
* [`84b906d5`](https://github.com/NixOS/nixpkgs/commit/84b906d5c44c0cd666b1f0ea28a9d1114e97a1b9) make-iso9660-image.sh: enable joliet extension
* [`519ace84`](https://github.com/NixOS/nixpkgs/commit/519ace844175c8ce22cc435a1ccd37d0d431e50b) iso-image: normalize volumeID
* [`0a634109`](https://github.com/NixOS/nixpkgs/commit/0a634109d495f6cfa36b1a5083e9631f38c2cb3c) iso-image: make sure volumeID is less than 32 chars
* [`17d67c00`](https://github.com/NixOS/nixpkgs/commit/17d67c00c92aa4a20b72da2c9e7add277660c4b0) iso-image: make $ARCH shorter
* [`1e925e15`](https://github.com/NixOS/nixpkgs/commit/1e925e1545b25d27bcd51f373f551fa28f49bbc2) performous: fix build (NixOS/nixpkgs#84841)
* [`c713b1b4`](https://github.com/NixOS/nixpkgs/commit/c713b1b49f86eba93dc8de596282731d2ea32f42) tor-browser-bundle-bin: 9.0.7 -> 9.0.9
* [`54ad1864`](https://github.com/NixOS/nixpkgs/commit/54ad1864617eb2a66b762e67d9a6ea06641bcbbf) nixos/network-interfaces: assertion for DHCP on bridges
* [`a6337014`](https://github.com/NixOS/nixpkgs/commit/a63370143f8a5067fb84efccf6fc6a4011616deb) pingus: 0.7.6 -> unstable; fixes build conflicts with dependency updates
* [`d676b041`](https://github.com/NixOS/nixpkgs/commit/d676b04132baed7540a65df212a12b9703968fc2) nix: 2.3.2 -> 2.3.3
* [`12b319cd`](https://github.com/NixOS/nixpkgs/commit/12b319cd86dcd4f6a70825b22ddcde29a90e8d91) nix-fallback-paths.nix: Fix x86_64-linux path
* [`609878ca`](https://github.com/NixOS/nixpkgs/commit/609878cafb6756769a7511cb24267ef91943082d) nix: 2.3.3 -> 2.3.4
* [`63c1baa3`](https://github.com/NixOS/nixpkgs/commit/63c1baa3ebea1457eedfa7f7fc640b0255df65d2) nix: Fix fallback paths
* [`ec11fd21`](https://github.com/NixOS/nixpkgs/commit/ec11fd21637535d87cdbac95c8caa095a73674ef) nixos/release-notes/rl-2003.xml: add highlights
* [`59d50ed9`](https://github.com/NixOS/nixpkgs/commit/59d50ed9db510d56a6fe95c58da08bf4ec45e997) maxscale: make broken package
* [`7c9f30be`](https://github.com/NixOS/nixpkgs/commit/7c9f30befaa5360a9c3d7d566fdf1922f84ee6c5) rl-2003: qa touchups
* [`f35b2f29`](https://github.com/NixOS/nixpkgs/commit/f35b2f29d283b6c71ad3dc7719fa83cd09b5dd9e) citra: 2019-10-05 -> 2020-03-21
* [`e8ae534a`](https://github.com/NixOS/nixpkgs/commit/e8ae534af7e5c1682e708a261e57550c9fbec142) pingus: move cmake to nativeBuildInputs
* [`da30881e`](https://github.com/NixOS/nixpkgs/commit/da30881e58fc18966105c430133c44b507fcb619) pantheon.appcenter: 3.2.3 -> 3.2.4
* [`9db8c338`](https://github.com/NixOS/nixpkgs/commit/9db8c3384736898c638e0620458b5748332a3016) pantheon.elementary-photos: 2.6.5 -> 2.7.0
* [`86822f8e`](https://github.com/NixOS/nixpkgs/commit/86822f8ed8f27980d9a1d6e48e98c45f20a843ea) pantheon.wingpanel: 2.3.0 -> 2.3.1
* [`f64401aa`](https://github.com/NixOS/nixpkgs/commit/f64401aa1f4be40865b4a6e2b0469051ce2dac5a) pantheon.pantheon-agent-polkit: 1.0.0 -> 1.0.1
* [`2165cd7a`](https://github.com/NixOS/nixpkgs/commit/2165cd7a810988b6d8df994fe5bf095dba5ebf8f) pantheon.elementary-capnet-assist: 2.2.4 -> 2.2.5
* [`99e05f5a`](https://github.com/NixOS/nixpkgs/commit/99e05f5a2356d566e8b7b6815086f9b34e4f93d1) pantheon.wingpanel-indicators-bluetooth: 2.1.4 -> 2.1.5
* [`698d2800`](https://github.com/NixOS/nixpkgs/commit/698d28006b39869a79ec4259f6f2b5eea3767f6f) pantheon.switchboard-plug-about: 2.6.1 -> 2.6.2
* [`44821b71`](https://github.com/NixOS/nixpkgs/commit/44821b7121027c2472a50ed8851b5d487526c990) pantheon.switchboard-plug-display: 2.2.0 -> 2.2.1
* [`2507c5f0`](https://github.com/NixOS/nixpkgs/commit/2507c5f0b4092894e0ffe55da3632f3f92e3b1f0) pantheon.switchboard-plug-applications: 2.1.6 -> 2.1.7
* [`e43ec384`](https://github.com/NixOS/nixpkgs/commit/e43ec384f72062876ddeb515ee359f7d76efa98e) pantheon.switchboard-plug-mouse-touchpad: 2.4.0 -> 2.4.1
* [`75a32d74`](https://github.com/NixOS/nixpkgs/commit/75a32d7434cdc29b036c7bdcf30281c9b9d54948) pantheon.switchboard-plug-pantheon-shell: 2.8.2 -> 2.8.3
* [`74ae6992`](https://github.com/NixOS/nixpkgs/commit/74ae69926e7615a2ea837f1e20c8a6ee77b652de) pantheon.switchboard-plug-security-privacy: 2.2.2 -> 2.2.3
* [`8d37cca4`](https://github.com/NixOS/nixpkgs/commit/8d37cca45f92aac77272b754215f3c7276661496) pantheon.wingpanel-applications-menu: 2.5.0 -> 2.6.0
* [`c2648731`](https://github.com/NixOS/nixpkgs/commit/c26487314f95eafe57dddddb45965b6d9fe29768) nixos/gnome-remote-desktop: enable pipewire
* [`dc256445`](https://github.com/NixOS/nixpkgs/commit/dc2564453759c33b9499c300c87dbf496a2b20b2) nginx-sso: 0.24.0 -> 0.24.1
* [`bb5bd4e8`](https://github.com/NixOS/nixpkgs/commit/bb5bd4e8314dd2ccd7f1bef72e9110f207afffde) python3Packages.nose2: 0.9.1 -> 0.9.2 and fix build for ZHF
* [`0e79744e`](https://github.com/NixOS/nixpkgs/commit/0e79744e20af6546e56a375d47a13d90aa1c24ed) release notes: Explain how to run nginx master as root. Fixes NixOS/nixpkgs#84391
* [`f3a3c969`](https://github.com/NixOS/nixpkgs/commit/f3a3c969fe27449da51b61efa1c75e63b844237a) nextcloud: Review installation upgrade warning wording
* [`c218f194`](https://github.com/NixOS/nixpkgs/commit/c218f19494b0d425d2e61d2d4bcdd21315fbbc57) nixos/release-notes: fix minor spelling mistake in the Nextcloud section
* [`8246657d`](https://github.com/NixOS/nixpkgs/commit/8246657ddb7564a101447f364008136ce1240d28) pythonPackages.awkward1: 0.1.38 -> 0.2.12
* [`f070c90c`](https://github.com/NixOS/nixpkgs/commit/f070c90c01637a6dce586e6962fa2bd6c31214ce) pythonPackages.awkward1: use pytestCheckHook
* [`42f4fa6b`](https://github.com/NixOS/nixpkgs/commit/42f4fa6b0bd3ed20c36589a3cb4814643ad98c04) snakemake: 5.9.1 -> 5.10.0
* [`1f4c8557`](https://github.com/NixOS/nixpkgs/commit/1f4c85578248e15c0f4f1e33cc216c8a7c87e822) snakemake: 5.10.0 -> 5.13.0 (NixOS/nixpkgs#83839)
* [`d0982c0e`](https://github.com/NixOS/nixpkgs/commit/d0982c0e0ec61efc53f1f39dc9f256c0759d1b7a) herwig: 7.2.0 -> 7.2.1
* [`b3f4b4dc`](https://github.com/NixOS/nixpkgs/commit/b3f4b4dc3cc2476a31568b1522b2736ab6c671f3) feh: 3.3 -> 3.4
* [`21b3020b`](https://github.com/NixOS/nixpkgs/commit/21b3020b1afb60ef0157d4af8cdf36b6910da7ea) Merge NixOS/nixpkgs#83022: simutrans: 120.2.2 -> 120.4.1 (unbreak)
* [`da764d22`](https://github.com/NixOS/nixpkgs/commit/da764d22ce3b698707861d58824843ded87cbb0a) rl-2003: remove section on intel GPU workaround
* [`8594285c`](https://github.com/NixOS/nixpkgs/commit/8594285c252ff70040ef8dea4e8417542808c276) nixos/doc: Document breaking change to Haskell dev shells
* [`1610b4ab`](https://github.com/NixOS/nixpkgs/commit/1610b4ab21896090381a562eb184aaea3aed8465) coqPackages.dpdgraph: fix build with OCaml ≥ 4.08
* [`26702dfb`](https://github.com/NixOS/nixpkgs/commit/26702dfb585cac4fe3816d301364e8c8a8b855c6) wdisplays: 2020-01-12 -> 2020-03-15
* [`56ff1184`](https://github.com/NixOS/nixpkgs/commit/56ff118499c3dfb99975674efa6820a6894c833b) packer: 1.5.4 -> 1.5.5
* [`9325edaa`](https://github.com/NixOS/nixpkgs/commit/9325edaa1eb6b462ac662356bc80a8074160c09a) linuxPackages.bpftrace: 0.9.3 -> 0.9.4
* [`96e35bf2`](https://github.com/NixOS/nixpkgs/commit/96e35bf2a0b78e1517c9946c76fcb6094a577aff) EmptyEpsilon: 2020.03.22 -> 2020.04.09
* [`0182312e`](https://github.com/NixOS/nixpkgs/commit/0182312e119121c27f59455ed0e35ccb6cc72b1e) mnemosyne: add googletrans and gtts python dependencies
* [`c2d20926`](https://github.com/NixOS/nixpkgs/commit/c2d209265d13ea9da4b1d623798b84aafa65176e) pythonPackages.googletrans: init at 2.4.0
* [`93e93f82`](https://github.com/NixOS/nixpkgs/commit/93e93f82e619af73367731718f67f98822ad8d0b) pythonPackages.gtts: init at 2.1.1
* [`ec099df0`](https://github.com/NixOS/nixpkgs/commit/ec099df0935adf67c6a2dfcd91f09553143faf16) mnemosyne: Fix 'Could not find Qt' segfault
* [`7a0cb9c3`](https://github.com/NixOS/nixpkgs/commit/7a0cb9c305eef194a2f8884240e10df9f662fae9) mnemosyne: Add pyopengl to silence OpenGL warning
* [`2fd2e031`](https://github.com/NixOS/nixpkgs/commit/2fd2e031a342c7ae117e5b63a9838ad2f41fdd30) mnemosyne: Install mnemosyne.desktop
* [`be8daae1`](https://github.com/NixOS/nixpkgs/commit/be8daae10cae108907b5ba0189a90900b3635bf4) linux: 4.4.218 -> 4.4.219
* [`585f6510`](https://github.com/NixOS/nixpkgs/commit/585f651020c49e857266392502e6342bac0a5567) linux: 4.14.175 -> 4.14.176
* [`788dd86a`](https://github.com/NixOS/nixpkgs/commit/788dd86a623439e07ddf4bf247671becfa15a9e1) linux: 4.19.114 -> 4.19.115
* [`44537fa3`](https://github.com/NixOS/nixpkgs/commit/44537fa3f495f698398fe49bbcbbf914aada2eb9) linux: 4.9.218 -> 4.9.219
* [`bab08a49`](https://github.com/NixOS/nixpkgs/commit/bab08a49dfb42d4aed5074cd4abc23b567ba81af) linux: 5.4.31 -> 5.4.32
* [`cb8b71c6`](https://github.com/NixOS/nixpkgs/commit/cb8b71c6455b1017eb3aeeae35f92f0e4f4adb45) linux: 5.5.16 -> 5.5.17
* [`ef7f4788`](https://github.com/NixOS/nixpkgs/commit/ef7f4788c7e58bab9220268a40c0bef57284b8e4) android-studio: Fix the license (unfree)
* [`9f0f06ac`](https://github.com/NixOS/nixpkgs/commit/9f0f06ac8beb8852d7ab3c5732e1c008c312f38d) freeradius: make debug logging optional
* [`3ad85969`](https://github.com/NixOS/nixpkgs/commit/3ad8596931f96ea6cb77f90efad50f45b4899a97) Revert "riot-desktop: wrap with wrapGAppsHook"
* [`22b5a32f`](https://github.com/NixOS/nixpkgs/commit/22b5a32fad48dea2100053fdbbd64d941377ac23) electron: fix wrapGAppsHook usage
* [`8aa17dea`](https://github.com/NixOS/nixpkgs/commit/8aa17dea0f181a61a16d6164cdd39b20bb21a531) modemmanager: 1.12.4 -> 1.12.6
* [`21750051`](https://github.com/NixOS/nixpkgs/commit/21750051b2686ade738d1eeb80c1955b0234aadd) modemmanager: 1.12.6 -> 1.12.8
* [`ecfd73db`](https://github.com/NixOS/nixpkgs/commit/ecfd73db44a9337ffbe4816c82c953399a19ca4f) acme: share accounts between certificates
* [`89b864de`](https://github.com/NixOS/nixpkgs/commit/89b864de6420c99837c8cebc9639b959c6d7cee6) ethminer: mark as broken
* [`3add50e5`](https://github.com/NixOS/nixpkgs/commit/3add50e56db4a618c19889652e92ef79b3e631bb) luminance-hdr: use Qt5's mkDerivation
* [`897182cd`](https://github.com/NixOS/nixpkgs/commit/897182cdaf580f238a5660aef7d70827480aa7a2) nixosTests.networking.virtual: fix with networkd
* [`8b40e890`](https://github.com/NixOS/nixpkgs/commit/8b40e8907be0b69bd541c4105cfaff3d05a93910) dysnomia: 0.9 -> 0.9.1
* [`6fd93c33`](https://github.com/NixOS/nixpkgs/commit/6fd93c338992d9812d345110e53abb8d8ea95660) nixos/dysnomia: fix documentRoot property
* [`7f9c1d0e`](https://github.com/NixOS/nixpkgs/commit/7f9c1d0ec3c4d2e164a32f0818be23a6c4eec23d) nixos/libinput: refer to libinput manual
* [`e393449b`](https://github.com/NixOS/nixpkgs/commit/e393449b43452b65ca7068c510253d0e1fa64d2b) airsonic: enable nginx.recommendedProxySettings with virtualHost
* [`946287b3`](https://github.com/NixOS/nixpkgs/commit/946287b3197f3adb7e72a6c8ad5b2b48abc113ad) mkl: 2020.0.166 -> 2020.1.217
* [`67e45efa`](https://github.com/NixOS/nixpkgs/commit/67e45efa3a48d87b00eb0b4c154f692e5887d35b) nix-zsh-completions: 0.4.3 -> 0.4.4 (NixOS/nixpkgs#85267)
* [`a438aed5`](https://github.com/NixOS/nixpkgs/commit/a438aed5a6ceda6beaa998af1c67a38f4b4c3156) tig: fix tig-completion's dependency on __git_complete
