### PR TITLE
niv nixpkgs-static: update c360f2a1 -> acaffd5f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nh2",
         "repo": "static-haskell-nix",
-        "rev": "c360f2a15f6947b411ecbd7ebaea925f6dbd68df",
-        "sha256": "0y6ppiagh6dbvdhhnrq572xnw2yzn6d0gcmajrfdgdfwhsl21g95",
+        "rev": "acaffd5fb807aa78f106eb3b4a99b05d3a1ec043",
+        "sha256": "1k2931w5x05yczvqkhjqd9ipgkk777215i0cjgqzkjqdzjzi08l1",
         "type": "tarball",
-        "url": "https://github.com/nh2/static-haskell-nix/archive/c360f2a15f6947b411ecbd7ebaea925f6dbd68df.tar.gz",
+        "url": "https://github.com/nh2/static-haskell-nix/archive/acaffd5fb807aa78f106eb3b4a99b05d3a1ec043.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for nixpkgs-static:
Commits: [nh2/static-haskell-nix@c360f2a1...acaffd5f](https://github.com/nh2/static-haskell-nix/compare/c360f2a15f6947b411ecbd7ebaea925f6dbd68df...acaffd5fb807aa78f106eb3b4a99b05d3a1ec043)

* [`acaffd5f`](https://github.com/nh2/static-haskell-nix/commit/acaffd5fb807aa78f106eb3b4a99b05d3a1ec043) Allow setting nixpkgs URL with `NIXPKGS_URL` env var
