### PR TITLE
Update niv-updater-action to v7

### DIFF
--- a/.github/workflows/niv-updates.yml
+++ b/.github/workflows/niv-updates.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v5
+        uses: knl/niv-updater-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         with:


### PR DESCRIPTION
This PR is triggered by [this issue](https://github.com/knl/niv-updater-action/issues/36) in niv-updater-action: The nixpkgs project is getting a lot of noise in their PRs due to GitHub placing back-references. This has been fixed in niv-updater-action v6.