### PR TITLE
niv niv: update f73bf8d5 -> 9d35b9e4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "f73bf8d584148677b01859677a63191c31911eae",
-        "sha256": "0jlmrx633jvqrqlyhlzpvdrnim128gc81q5psz2lpp2af8p8q9qs",
+        "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
+        "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/f73bf8d584148677b01859677a63191c31911eae.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@f73bf8d5...9d35b9e4](https://github.com/nmattia/niv/compare/f73bf8d584148677b01859677a63191c31911eae...9d35b9e4837ab88517210b1701127612c260eccf)

* [`2818ce64`](https://github.com/nmattia/niv/commit/2818ce648c7e4468e8b70f46df2854e1cb34b98e) Fix macOS build
* [`66e79bc3`](https://github.com/nmattia/niv/commit/66e79bc38a8a2571caa767a1578b50521d8ce13d) Define Cachix signing key in action
* [`0fe342db`](https://github.com/nmattia/niv/commit/0fe342db13a665308309e18f96a7e2bb7a7eea16) Update nix GitHub action
* [`dd17834c`](https://github.com/nmattia/niv/commit/dd17834c49aa765c222d77b6d22f8de7af03a3c1) Add FAQ section to README
* [`fb1716a9`](https://github.com/nmattia/niv/commit/fb1716a9c898f6375a0baa5740af68b7aef5c154) Update to nixpkgs 20.03
* [`c27f5a6c`](https://github.com/nmattia/niv/commit/c27f5a6c57de4495045450b6587d4a2c489851c8) Allow custom nixpkgs
* [`2521c74b`](https://github.com/nmattia/niv/commit/2521c74b8bc3da3762cc9adf69b834fd1853b96c) Change default repo to NixOS/nixpkgs
* [`0f50051d`](https://github.com/nmattia/niv/commit/0f50051d3c9afa1c8517a37618701ed57996ce21) Drop nixpkgs-channels in README, usage and examples
* [`79b6cc4d`](https://github.com/nmattia/niv/commit/79b6cc4d76f5a6fd9d150f7a50b8407b84232bdb) Factor out default nixpkgs branch
* [`a78983cd`](https://github.com/nmattia/niv/commit/a78983cd556832890332c7718d9721d1fe6538cd) Explain YesNixpkgs argument
* [`99771dd1`](https://github.com/nmattia/niv/commit/99771dd10d889bdb08efed90ba31669bf6dbd26a) Use release-20.03 by default
* [`e5f7c0a4`](https://github.com/nmattia/niv/commit/e5f7c0a4d3c40f3bc9b18a3dba2f7fd777f0f0a6) Release 0.2.14
* [`febd3530`](https://github.com/nmattia/niv/commit/febd3530f0c2f2fb74752ee4d9dd2518d302f618) Update installation instructions
* [`5f35efd9`](https://github.com/nmattia/niv/commit/5f35efd949612b3649c845e6b8a30ddb9fbe2f9a) Fix logline
* [`3c7cecd8`](https://github.com/nmattia/niv/commit/3c7cecd8e6c37f86189c7d496e106ec9695ecbff) Show command when nix-prefetch-url fails
* [`6bb2a97d`](https://github.com/nmattia/niv/commit/6bb2a97db75fb33744699b5fa85035f16e83122f) Add ormolu to dev environment
* [`7572ac8d`](https://github.com/nmattia/niv/commit/7572ac8ddb507a1e982b7510fc59ceb182b622b8) Add a formatting script
* [`b066716c`](https://github.com/nmattia/niv/commit/b066716ced160eb241a902e40d27c04ee1ce191d) Add script/fmt to GitHub CI job
* [`b0e3ca55`](https://github.com/nmattia/niv/commit/b0e3ca55a99acb2e794ff26b653048e35b1ca0ff) ci: run script/fmt in the nix environment
* [`8e0e8017`](https://github.com/nmattia/niv/commit/8e0e8017c59fccdd754b4626d33799c5ce36c282) Replace default.nix with-rec with let
* [`fc2cd34b`](https://github.com/nmattia/niv/commit/fc2cd34b8338062dbac02e5cfa6969c58126a427) Use ormolu from nixpkgs
* [`1edb6856`](https://github.com/nmattia/niv/commit/1edb6856ad161a0f6e1db7568a16505c86fb6f89) Run Ormolu on all files instead of changed
* [`e0bfb5d0`](https://github.com/nmattia/niv/commit/e0bfb5d007887b906d40e6232e80af2f67675d3f) Run Ormolu
* [`0d30bfd7`](https://github.com/nmattia/niv/commit/0d30bfd7b085147b181f7f71263e5d711dfc90b1) Use a single GitHub workflow
* [`c0a61e62`](https://github.com/nmattia/niv/commit/c0a61e6283933fa6eed6d3451ffd86c9df5209ec) Add subpath handling to FAQ
* [`fcfd1111`](https://github.com/nmattia/niv/commit/fcfd1111c6884238b9e94e1ed446abe71abdf12d) Update README.tpl.md
* [`15c82fd1`](https://github.com/nmattia/niv/commit/15c82fd18470472bd90ac6f573e89263f73b6a2b) Add NixOS module example
* [`ab9cc41c`](https://github.com/nmattia/niv/commit/ab9cc41caf44d1f1d465d8028e4bc0096fd73238) Add CI check for formatting
* [`303f442c`](https://github.com/nmattia/niv/commit/303f442c43f918bc43400ab4a0b662a82ca7748b) Cache `Box` results
* [`24eabfbf`](https://github.com/nmattia/niv/commit/24eabfbfaa74117d66fa27463a90b237b1b01746) Remove script/update
* [`38a536e5`](https://github.com/nmattia/niv/commit/38a536e59e6e18c509cd2c6492f06b7da39a0e1e) Add NIV_OVERRIDE_{...}
* [`45c4ed5a`](https://github.com/nmattia/niv/commit/45c4ed5af1638d25ac84b84e4d06b3a05c2eb183) Document NIV_OVERRIDE and add FAQ TOC
* [`bee0b4ca`](https://github.com/nmattia/niv/commit/bee0b4ca510535498a6523610a0de9702a9678fe) Release 0.2.15
* [`84827485`](https://github.com/nmattia/niv/commit/84827485e2eff1681b9a2834ef10b8eba6bf341c) Make sources.nix remote friendly
* [`e82eb322`](https://github.com/nmattia/niv/commit/e82eb322ea32a747a51c431d7787221bcc6d9038) Release 0.2.16
* [`7abb350a`](https://github.com/nmattia/niv/commit/7abb350a10955cee1c48a3732cb4a4db43c5611e) Refactor eval tests
* [`13c88bfc`](https://github.com/nmattia/niv/commit/13c88bfcc3749d6530f1d9b8c860877188062f29) Add source name sanitization test
* [`5c966856`](https://github.com/nmattia/niv/commit/5c966856bc8b49ab34718fda760b3e4ad3fb2b96) Sanitize source name
* [`f0be4cea`](https://github.com/nmattia/niv/commit/f0be4cea7d2888837d5b0e609c2014c287fe7f69) Steal sanitizeDrvName
* [`1294b321`](https://github.com/nmattia/niv/commit/1294b321c8dd0dfcf84c876929693187a08ed504) Stop using ref in builtins.fetchGit fetcher
* [`d13bf5ff`](https://github.com/nmattia/niv/commit/d13bf5ff11850f49f4282d59b25661c45a851936) Add information about ref handling
* [`de840016`](https://github.com/nmattia/niv/commit/de84001689fcc9c751d3ef749187cf6cb72fef2f) sources.nix: bootstrap with a custom system
* [`89ae775e`](https://github.com/nmattia/niv/commit/89ae775e9dfc2571f912156dd2f8627e14d4d507) Add --rev and -r
* [`fad2a6cb`](https://github.com/nmattia/niv/commit/fad2a6cbfb2e7cdebb7cb0ad2f5cc91e2c9bc06b) Update netlify deploy
* [`6ae4c770`](https://github.com/nmattia/niv/commit/6ae4c7700bf8a4db3631336b08be2a2a92fdd854) Don't push drv files to cachix
* [`b50a0107`](https://github.com/nmattia/niv/commit/b50a0107691487d4948c2078a77afdc0d1f20e8b) Show version with --version
* [`5c2b9205`](https://github.com/nmattia/niv/commit/5c2b92052603d810f67984c913b393cc7bdcf056) Update changelog
* [`dd13098d`](https://github.com/nmattia/niv/commit/dd13098d01eaa6be68237e7e38f96782b0480755) Release 0.2.17
* [`48dee993`](https://github.com/nmattia/niv/commit/48dee993d2be3618d489e59fc29b196e4152d538) Prepend environment variables with NIV_
* [`29ddaaf4`](https://github.com/nmattia/niv/commit/29ddaaf4e099c3ac0647f5b652469dfc79cd3b53) Release 0.2.18
* [`9d35b9e4`](https://github.com/nmattia/niv/commit/9d35b9e4837ab88517210b1701127612c260eccf) Turn NIV_OVERRIDE values into paths
