### PR TITLE
niv niv: update 9d35b9e4 -> 20c89927

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
-        "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
+        "rev": "20c899271f288d33114760bc298838575fc6c7f9",
+        "sha256": "07zswk6dhlydihl9g6skmy52grjvqpra8r98f2dmbgwzc1yhjhxq",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/20c899271f288d33114760bc298838575fc6c7f9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@9d35b9e4...20c89927](https://github.com/nmattia/niv/compare/9d35b9e4837ab88517210b1701127612c260eccf...20c899271f288d33114760bc298838575fc6c7f9)

* [`497807b3`](https://github.com/nmattia/niv/commit/497807b3173bb4b1f84ffcf2c4c0d7f8afc99209) Respect type attribute
* [`c3159e7c`](https://github.com/nmattia/niv/commit/c3159e7c9e4835dabbdb6feb1c97715e8b32b8c8) Update CHANGELOG.md
* [`45faf8f3`](https://github.com/nmattia/niv/commit/45faf8f33145ba5bb5956015d1fff7d57b755873) Update README.md
* [`205240c2`](https://github.com/nmattia/niv/commit/205240c2780008397d030665eb8b5c677d5a93cd) Remove stray uncompleted sentence
* [`20c89927`](https://github.com/nmattia/niv/commit/20c899271f288d33114760bc298838575fc6c7f9) Fix README*
