### PR TITLE
niv niv: update 20c89927 -> ba57d5a2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "20c899271f288d33114760bc298838575fc6c7f9",
-        "sha256": "07zswk6dhlydihl9g6skmy52grjvqpra8r98f2dmbgwzc1yhjhxq",
+        "rev": "ba57d5a29b4e0f2085917010380ef3ddc3cf380f",
+        "sha256": "1kpsvc53x821cmjg1khvp1nz7906gczq8mp83664cr15h94sh8i4",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/20c899271f288d33114760bc298838575fc6c7f9.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/ba57d5a29b4e0f2085917010380ef3ddc3cf380f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@20c89927...ba57d5a2](https://github.com/nmattia/niv/compare/20c899271f288d33114760bc298838575fc6c7f9...ba57d5a29b4e0f2085917010380ef3ddc3cf380f)

* [`ba57d5a2`](https://github.com/nmattia/niv/commit/ba57d5a29b4e0f2085917010380ef3ddc3cf380f) Clarify Git error on missing branch
